### PR TITLE
Fixed: Draws Aren't Displayed Properly

### DIFF
--- a/TTT-WPFApp/GameTile.cs
+++ b/TTT-WPFApp/GameTile.cs
@@ -33,18 +33,19 @@ namespace TTT_WPFApp
         protected override void OnClick()
         {
             _boardTile.Click();
-            _mainWindow.UpdateAllTiles();
+            Update();
+            if (_myGame.GameOver)
+            {
+                _mainWindow.UpdateAllTiles();
+            }
         }
 
         public void Update()
         {
+            SetTeamAppearance();
             if (_myGame.GameOver && !IsWinningTile())
             {
                 SetLosingAppearance();
-            }
-            else
-            {
-                SetTeamAppearance();
             }
         }
 


### PR DESCRIPTION
- only clicked tile updates, unless game is over
- TeamAppearance is always applied, before LosingAppearance