### PR TITLE
Fixed Drawn Game UI Bug

### DIFF
--- a/CPU-Opponent/GameAgainstCPU.cs
+++ b/CPU-Opponent/GameAgainstCPU.cs
@@ -13,7 +13,7 @@ namespace CPU_Opponent
 
         public override void NotifyMove()
         {
-            if (CurrentPlayer == _cpuPlayer.CPUTeam)
+            if (CurrentPlayer == _cpuPlayer.CPUTeam && !GameOver)
             {
                 _cpuPlayer.MakeMove();
             }

--- a/TTT-Library/TicTacToeGame.cs
+++ b/TTT-Library/TicTacToeGame.cs
@@ -18,8 +18,6 @@ namespace TTT_Library
 
         public PlayerMove previousMove { get { return _moveHistory.Peek(); } }
 
-        
-
         public GameBoard Board { get; private set; }
         private Judge _judge;
 


### PR DESCRIPTION
- CPUOpponent only makes moves while the game is ongoing
- my end-of-game check was looking for 9 moves in the move history & the CPU was managing to submit a 10th move